### PR TITLE
Change the rcorder(8) of `rc.d/triton` to start before `SERVERS`.

### DIFF
--- a/triton-freebsd-guesttools/etc/rc.d/triton
+++ b/triton-freebsd-guesttools/etc/rc.d/triton
@@ -1,7 +1,8 @@
 #!/bin/sh
 
+# REQUIRE: NETWORKING
 # PROVIDE: triton
-# BEFORE: LOGIN
+# BEFORE: SERVERS
 
 . /etc/rc.subr
 


### PR DESCRIPTION
Previously it was possible for local servers to start before the `rc.d/triton` init script had formatted the data partition.  Now `triton` starts before `SERVERS` and is guaranteed to start after `NETWORKING`.  By chance, `triton` was ordered before `local` (line 118 below in the before section):

As seen by `rcorder /etc/rc.d/* | cat -n`:

Before:
```
   107  /etc/rc.d/DAEMON
   108  /etc/rc.d/utx
   109  /etc/rc.d/ugidfw
   110  /etc/rc.d/ubthidhci
   111  /etc/rc.d/triton
   112  /etc/rc.d/timed
   113  /etc/rc.d/apm
   114  /etc/rc.d/apmd
   115  /etc/rc.d/bootparams
   116  /etc/rc.d/hcsecd
   117  /etc/rc.d/bthidd
   118  /etc/rc.d/local
   119  /etc/rc.d/lpd
   120  /etc/rc.d/motd
   121  /etc/rc.d/mountlate
   122  /etc/rc.d/nscd
   123  /etc/rc.d/ntpd
   124  /etc/rc.d/powerd
   125  /etc/rc.d/rarpd
   126  /etc/rc.d/rctl
   127  /etc/rc.d/sdpd
   128  /etc/rc.d/rfcomm_pppd_server
   129  /etc/rc.d/rtadvd
   130  /etc/rc.d/rwho
   131  /etc/rc.d/LOGIN
```

After:
```
    59  /etc/rc.d/NETWORKING
    60  /etc/rc.d/mountcritremote
    61  /etc/rc.d/newsyslog
    62  /etc/rc.d/syslogd
    63  /etc/rc.d/ntpdate
    64  /etc/rc.d/rpcbind
    65  /etc/rc.d/devfs
    66  /etc/rc.d/ipmon
    67  /etc/rc.d/kdc
    68  /etc/rc.d/mdconfig2
    69  /etc/rc.d/triton
    70  /etc/rc.d/watchdogd
    71  /etc/rc.d/savecore
    72  /etc/rc.d/archdep
    73  /etc/rc.d/abi
    74  /etc/rc.d/SERVERS
```